### PR TITLE
updating readme's install instructions to use latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add `sans_password` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:sans_password, "~> 1.0.0-beta"}]
+  [{:sans_password, "~> 1.1.0"}]
 end
 ```
 


### PR DESCRIPTION
`1.0.0-beta` won't install with the default guardian 2.3 - updated the readme to point at the latest version